### PR TITLE
fix: go module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/roondar/goawx
+module github.com/veepee-oss/goawx
 
 go 1.14


### PR DESCRIPTION
Module was moved to `veepee-oss` but not renamed.
As a result, requiring it in another project results in warnings about the module being required with a specific name but not being named that way.